### PR TITLE
Fix incompatibility with Elytra Trims 1.1.10, when used with new trim patterns

### DIFF
--- a/common/src/main/java/com/bawnorton/allthetrims/mixin/client/PalettedPermutationsAtlasSourceMixin.java
+++ b/common/src/main/java/com/bawnorton/allthetrims/mixin/client/PalettedPermutationsAtlasSourceMixin.java
@@ -67,7 +67,10 @@ public abstract class PalettedPermutationsAtlasSourceMixin {
         if (original.isPresent()) return original;
 
         String path = identifier.getPath();
-        Identifier originalIdentifier = identifier.withPath(path.substring(0, path.lastIndexOf('_')) + ".png");
+        int pathEnd = path.lastIndexOf('_');
+        Identifier originalIdentifier = pathEnd > 0
+                ? identifier.withPath(path.substring(0, pathEnd) + ".png")
+                : identifier;
         Optional<Resource> optionalResource = instance.getResource(originalIdentifier);
         if (optionalResource.isEmpty()) return optionalResource;
 

--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -1,7 +1,7 @@
 biome_makeover_version=fabric-1.20.0-1.10.1
-elytra_trims_version=MggVxdpI
+elytra_trims_version=1.1.10-beta.4
 betterend_version=4.0.7
-bclib_version=3.0.10
+bclib_version=3.0.12
 wunderlib_version=1.1.3
 modmenu_version=7.1.0
 show_me_your_skin_version=1.6.6+1.20


### PR DESCRIPTION
See https://github.com/kikugie/elytra-trims/issues/18  
Since ET 1.1.10 there's an option for attempting to register trims for every existing armor trim. This utterly shits itself with All The Trims because it checks for last "_", which in Elytra Trim's texture load spam doesn't exist. The fix is to check if the underscore was found beforehand, and modify the path only in that case.  
Yes, it actually works, I tested.

Also it updates BCLib bcos for some reason 3.0.10 is no longer available.