### PR TITLE
Fix newer versions of MixinSquared breaking older versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -114,7 +114,7 @@ if(loader.isFabric) {
         modImplementation("net.fabricmc:fabric-loader:${loader.getVersion()}")
         modImplementation("net.fabricmc.fabric-api:fabric-api:${property("fabric_api")}+$minecraftVersion")
 
-        include(implementation(annotationProcessor("com.bawnorton.mixinsquared:mixinsquared-fabric:${property("mixin_squared")}")!!)!!)
+        include(implementation(annotationProcessor("com.github.bawnorton:mixinsquared-fabric:${property("mixin_squared")}")!!)!!)
 
         modImplementation("com.terraformersmc:modmenu:${property("mod_menu")}")
 
@@ -150,8 +150,8 @@ if (loader.isNeoForge) {
     dependencies {
         neoForge("net.neoforged:neoforge:${loader.getVersion()}")
 
-        compileOnly(annotationProcessor("com.bawnorton.mixinsquared:mixinsquared-common:0.2.0-beta.6")!!)
-        implementation(include("com.bawnorton.mixinsquared:mixinsquared-forge:0.2.0-beta.6")!!)
+        compileOnly(annotationProcessor("com.github.bawnorton:mixinsquared-common:0.2.0-beta.6")!!)
+        implementation(include("com.github.bawnorton:mixinsquared-forge:0.2.0-beta.6")!!)
 
         modCompileOnly("maven.modrinth:elytra-trims:${property("elytra_trims")}").stripAw(project)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -114,7 +114,7 @@ if(loader.isFabric) {
         modImplementation("net.fabricmc:fabric-loader:${loader.getVersion()}")
         modImplementation("net.fabricmc.fabric-api:fabric-api:${property("fabric_api")}+$minecraftVersion")
 
-        include(implementation(annotationProcessor("com.github.bawnorton:mixinsquared-fabric:${property("mixin_squared")}")!!)!!)
+        include(implementation(annotationProcessor("com.github.bawnorton.mixinsquared:mixinsquared-fabric:${property("mixin_squared")}")!!)!!)
 
         modImplementation("com.terraformersmc:modmenu:${property("mod_menu")}")
 
@@ -150,8 +150,8 @@ if (loader.isNeoForge) {
     dependencies {
         neoForge("net.neoforged:neoforge:${loader.getVersion()}")
 
-        compileOnly(annotationProcessor("com.github.bawnorton:mixinsquared-common:0.2.0-beta.6")!!)
-        implementation(include("com.github.bawnorton:mixinsquared-forge:0.2.0-beta.6")!!)
+        compileOnly(annotationProcessor("com.github.bawnorton.mixinsquared:mixinsquared-common:0.2.0-beta.6")!!)
+        implementation(include("com.github.bawnorton.mixinsquared:mixinsquared-forge:0.2.0-beta.6")!!)
 
         modCompileOnly("maven.modrinth:elytra-trims:${property("elytra_trims")}").stripAw(project)
 


### PR DESCRIPTION
MixinSquared migrated from jitpack to my own maven when 0.2.0-beta.5 released, I did not know at the time that this would break compatibility with older versions of MixinSquared as the maven group changed from `com.github.bawnorton` to `com.bawnorton` causing mod loaders to think they were different mods. 

This PR reverts that change to allow for compatibility with older versions of MixinSquared.

 I aplogize for the inconvenience, I was not aware of the implications of this change.

_This PR was generated automatically_